### PR TITLE
Removed token_type as a required parameter

### DIFF
--- a/src/fkooman/OAuth/Client/AccessToken.php
+++ b/src/fkooman/OAuth/Client/AccessToken.php
@@ -19,6 +19,9 @@ namespace fkooman\OAuth\Client;
 
 class AccessToken extends Token
 {
+    /** default token_type */
+    const DEFAULT_TOKEN_TYPE = "bearer";
+
     /** access_token VARCHAR(255) NOT NULL */
     private $accessToken;
 
@@ -37,7 +40,7 @@ class AccessToken extends Token
                 throw new TokenException(sprintf("missing field '%s'", $key));
             }
         }
-        $data['token_type'] = array_key_exists('token_type', $data) ? $data['token_type'] : "bearer";
+        $data['token_type'] = array_key_exists('token_type', $data) ? $data['token_type'] : self::DEFAULT_TOKEN_TYPE;
         $this->setAccessToken($data['access_token']);
         $this->setTokenType($data['token_type']);
         $expiresIn = array_key_exists('expires_in', $data) ? $data['expires_in'] : null;

--- a/src/fkooman/OAuth/Client/TokenResponse.php
+++ b/src/fkooman/OAuth/Client/TokenResponse.php
@@ -19,6 +19,7 @@ namespace fkooman\OAuth\Client;
 
 class TokenResponse
 {
+    const DEFAULT_TOKEN_TYPE = "bearer";
     private $accessToken;
     private $tokenType;
     private $expiresIn;
@@ -41,7 +42,7 @@ class TokenResponse
                 throw new TokenResponseException(sprintf("missing field '%s'", $key));
             }
         }
-        $data['token_type'] = array_key_exists('token_type', $data) ? $data['token_type'] : "bearer";
+        $data['token_type'] = array_key_exists('token_type', $data) ? $data['token_type'] : self::DEFAULT_TOKEN_TYPE;
         $t = new static($data['access_token'], $data['token_type']);
         if (array_key_exists('expires_in', $data)) {
             $t->setExpiresIn($data['expires_in']);


### PR DESCRIPTION
The Salesforce OAuth implementation does not return token_type in the
Access Token Response so making it optional. Defaults to "bearer" if
it's not passed back.
